### PR TITLE
feat: add ansattporten provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,11 @@ IDPORTEN_AUDIENCE=default
 # Alternatively configure IDPORTEN_ISSUER and IDPORTEN_JWKS_URI explicitly.
 IDPORTEN_WELL_KNOWN_URL=http://localhost:8080/idporten/.well-known/openid-configuration
 
+ANSATTPORTEN_ENABLED=true
+# expected audience for tokens returned by mock-oauth2-server
+ANSATTPORTEN_AUDIENCE=default
+# Alternatively configure ANSATTPORTEN_ISSUER and ANSATTPORTEN_JWKS_URI explicitly.
+ANSATTPORTEN_WELL_KNOWN_URL=http://localhost:8080/ansattporten/.well-known/openid-configuration
+
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 OTEL_RESOURCE_ATTRIBUTES=downstream.app.name=myapplication,downstream.app.namespace=mynamespace,downstream.app.cluster=mycluster,nais.pod.name=myapplication-7dc9b97dc9-vh64d

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Texas is currently tailored for use with a subset of authorization servers and p
 
 - [Entra ID (formerly known as Azure AD)](https://learn.microsoft.com/en-us/entra/identity-platform/v2-overview)
 - [ID-porten](https://docs.digdir.no/docs/idporten/idporten/idporten_overordnet.html)
+- [Ansattporten](https://docs.digdir.no/docs/ansattporten/ansattporten_om.html)
 - [Maskinporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_overordnet)
 - [TokenX / Tokendings](https://github.com/nais/tokendings)
 

--- a/doc/openapi-spec.json
+++ b/doc/openapi-spec.json
@@ -312,7 +312,8 @@
           "entra_id",
           "tokenx",
           "maskinporten",
-          "idporten"
+          "idporten",
+          "ansattporten"
         ]
       },
       "IntrospectRequest": {
@@ -333,7 +334,7 @@
       },
       "IntrospectResponse": {
         "type": "object",
-        "description": "Based on RFC 7662 introspection response from section 2.2.\n\nClaims from the original token are copied verbatim to the introspection response as additional properties.\nThe claims present depend on the identity provider.\nPlease refer to the Nais documentation for details:\n\n- [Entra ID](https://doc.nais.io/auth/entra-id/reference/#claims)\n- [ID-porten](https://doc.nais.io/auth/idporten/reference/#claims)\n- [Maskinporten](https://doc.nais.io/auth/maskinporten/reference/#claims)\n- [TokenX](https://doc.nais.io/auth/tokenx/reference/#claims)",
+        "description": "Based on RFC 7662 introspection response from section 2.2.\n\nClaims from the original token are copied verbatim to the introspection response as additional properties.\nThe claims present depend on the identity provider.\nPlease refer to the Nais documentation for details:\n\n- [Entra ID](https://doc.nais.io/auth/entra-id/reference/#claims)\n- [ID-porten](https://doc.nais.io/auth/idporten/reference/#claims)\n- [Maskinporten](https://doc.nais.io/auth/maskinporten/reference/#claims)\n- [TokenX](https://doc.nais.io/auth/tokenx/reference/#claims)\n\nFor Ansattporten specifically, please refer to the Digdir documentation for details:\n- [Ansattporten](https://docs.digdir.no/docs/ansattporten/ansattporten_om.html)",
         "required": [
           "active"
         ],

--- a/hack/roundtrip-ansattporten.sh
+++ b/hack/roundtrip-ansattporten.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+user_token_response=$(curl -s -X POST http://localhost:8080/ansattporten/token -d "grant_type=authorization_code&code=yolo&client_id=yolo&client_secret=bolo")
+user_token=$(echo ${user_token_response} | jq -r .access_token)
+
+validation=$(curl -s -X POST http://localhost:3000/api/v1/introspect -H "content-type: application/json" -d "{\"token\": \"${user_token}\", \"identity_provider\": \"ansattporten\"}")
+
+echo
+echo "User token:"
+echo "${user_token}"
+
+echo
+echo "Validation:"
+echo "${validation}" | jq -S .

--- a/mise.toml
+++ b/mise.toml
@@ -79,6 +79,7 @@ run = [
     "./hack/roundtrip-azure-cc.sh",
     "./hack/roundtrip-azure-obo.sh",
     "./hack/roundtrip-idporten.sh",
+    "./hack/roundtrip-ansattporten.sh",
     "./hack/roundtrip-maskinporten.sh",
     "./hack/roundtrip-maskinporten-rar.sh",
     "./hack/roundtrip-tokenx.sh",

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub entra_id: Option<Provider>,
     pub token_x: Option<Provider>,
     pub idporten: Option<Provider>,
+    pub ansattporten: Option<Provider>,
 }
 
 #[derive(Serialize, Clone, Debug, Default)]
@@ -29,6 +30,7 @@ impl Config {
         let maskinporten = RawProvider::new_from_maskinporten_env()?;
         let token_x = RawProvider::new_from_tokenx_env()?;
         let idporten = RawProvider::new_from_idporten_env()?;
+        let ansattporten = RawProvider::new_from_ansattporten_env()?;
 
         Ok(Self {
             bind_address: std::env::var("BIND_ADDRESS").unwrap_or("127.0.0.1:3000".to_string()),
@@ -47,6 +49,10 @@ impl Config {
             },
             idporten: match idporten {
                 Some(provider) => Some(provider.resolve(ProviderKind::IDPorten).await?),
+                None => None,
+            },
+            ansattporten: match ansattporten {
+                Some(provider) => Some(provider.resolve(ProviderKind::Ansattporten).await?),
                 None => None,
             },
         })
@@ -85,6 +91,7 @@ pub enum Error {
 enum ProviderKind {
     EntraID,
     IDPorten,
+    Ansattporten,
     Maskinporten,
     TokenX,
 }
@@ -112,6 +119,13 @@ impl ProviderKind {
                 well_known_env: "IDPORTEN_WELL_KNOWN_URL",
                 issuer_env: "IDPORTEN_ISSUER",
                 jwks_uri_env: "IDPORTEN_JWKS_URI",
+                token_endpoint_env: "",
+            },
+            ProviderKind::Ansattporten => ProviderEnv {
+                provider_name: "ansattporten",
+                well_known_env: "ANSATTPORTEN_WELL_KNOWN_URL",
+                issuer_env: "ANSATTPORTEN_ISSUER",
+                jwks_uri_env: "ANSATTPORTEN_JWKS_URI",
                 token_endpoint_env: "",
             },
             ProviderKind::Maskinporten => ProviderEnv {
@@ -203,6 +217,21 @@ impl RawProvider {
         }))
     }
 
+    fn new_from_ansattporten_env() -> Result<Option<Self>, Error> {
+        if !Self::enabled_from_env("ANSATTPORTEN_ENABLED")? {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            client_id: must_read_env("ANSATTPORTEN_AUDIENCE")?,
+            client_jwk: None,
+            well_known_url: read_env("ANSATTPORTEN_WELL_KNOWN_URL"),
+            jwks_uri: read_env("ANSATTPORTEN_JWKS_URI"),
+            issuer: read_env("ANSATTPORTEN_ISSUER"),
+            token_endpoint: None,
+        }))
+    }
+
     fn new_from_tokenx_env() -> Result<Option<Self>, Error> {
         if !Self::enabled_from_env("TOKEN_X_ENABLED")? {
             return Ok(None);
@@ -223,7 +252,7 @@ impl RawProvider {
         let should_fetch_metadata = self.well_known_url.is_some()
             && (self.issuer.is_none()
                 || self.jwks_uri.is_none()
-                || (kind != ProviderKind::IDPorten && self.token_endpoint.is_none()));
+                || (kind != ProviderKind::IDPorten && kind != ProviderKind::Ansattporten && self.token_endpoint.is_none()));
 
         let metadata = if should_fetch_metadata {
             let url = self.well_known_url.as_deref().unwrap_or_default();
@@ -246,7 +275,7 @@ impl RawProvider {
             })?;
         let token_endpoint = self.token_endpoint.or(metadata.token_endpoint);
 
-        if kind != ProviderKind::IDPorten && token_endpoint.is_none() {
+        if kind != ProviderKind::IDPorten && kind != ProviderKind::Ansattporten && token_endpoint.is_none() {
             return Err(Error::MissingProviderConfigField {
                 provider: env.provider_name,
                 field_env: env.token_endpoint_env,
@@ -393,6 +422,36 @@ mod tests {
         assert_eq!(resolved.issuer, "https://idporten.example");
         assert_eq!(resolved.token_endpoint, None);
         assert_eq!(resolved.jwks_uri, "https://idporten.example/jwks");
+    }
+
+    #[tokio::test]
+    async fn ansattporten_does_not_require_token_endpoint_in_metadata() {
+        let (base_url, _server) = metadata_server(vec![(
+            "/ansattporten/.well-known/openid-configuration",
+            json!({
+                "issuer": "https://ansattporten.example",
+                "jwks_uri": "https://ansattporten.example/jwks"
+            }),
+        )])
+        .await;
+
+        let resolved = RawProvider {
+            client_id: "client-id".to_string(),
+            client_jwk: None,
+            well_known_url: Some(format!(
+                "{base_url}/ansattporten/.well-known/openid-configuration"
+            )),
+            issuer: None,
+            token_endpoint: None,
+            jwks_uri: None,
+        }
+        .resolve(ProviderKind::Ansattporten)
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.issuer, "https://ansattporten.example");
+        assert_eq!(resolved.token_endpoint, None);
+        assert_eq!(resolved.jwks_uri, "https://ansattporten.example/jwks");
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,7 +257,8 @@ impl RawProvider {
         let should_fetch_metadata = self.well_known_url.is_some()
             && (self.issuer.is_none()
                 || self.jwks_uri.is_none()
-                || (matches!(env.token_capability, TokenCapability::Exchange(_)) && self.token_endpoint.is_none()));
+                || (matches!(env.token_capability, TokenCapability::Exchange(_))
+                    && self.token_endpoint.is_none()));
 
         let metadata = if should_fetch_metadata {
             let url = self.well_known_url.as_deref().unwrap_or_default();
@@ -280,14 +281,14 @@ impl RawProvider {
             })?;
         let token_endpoint = self.token_endpoint.or(metadata.token_endpoint);
 
-        if let TokenCapability::Exchange(field_env) = env.token_capability {
-            if token_endpoint.is_none() {
-                return Err(Error::MissingProviderConfigField {
-                    provider: env.provider_name,
-                    field_env,
-                    well_known_env: env.well_known_env,
-                });
-            }
+        if let TokenCapability::Exchange(field_env) = env.token_capability
+            && token_endpoint.is_none()
+        {
+            return Err(Error::MissingProviderConfigField {
+                provider: env.provider_name,
+                field_env,
+                well_known_env: env.well_known_env,
+            });
         }
 
         Ok(Provider {

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,7 +87,7 @@ pub enum Error {
     },
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum ProviderKind {
     EntraID,
     IDPorten,
@@ -96,12 +96,17 @@ enum ProviderKind {
     TokenX,
 }
 
+enum TokenCapability {
+    Exchange(&'static str),
+    IntrospectOnly,
+}
+
 struct ProviderEnv {
     provider_name: &'static str,
     well_known_env: &'static str,
     issuer_env: &'static str,
     jwks_uri_env: &'static str,
-    token_endpoint_env: &'static str,
+    token_capability: TokenCapability,
 }
 
 impl ProviderKind {
@@ -112,35 +117,35 @@ impl ProviderKind {
                 well_known_env: "AZURE_APP_WELL_KNOWN_URL",
                 issuer_env: "AZURE_OPENID_CONFIG_ISSUER",
                 jwks_uri_env: "AZURE_OPENID_CONFIG_JWKS_URI",
-                token_endpoint_env: "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT",
+                token_capability: TokenCapability::Exchange("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
             },
             ProviderKind::IDPorten => ProviderEnv {
                 provider_name: "idporten",
                 well_known_env: "IDPORTEN_WELL_KNOWN_URL",
                 issuer_env: "IDPORTEN_ISSUER",
                 jwks_uri_env: "IDPORTEN_JWKS_URI",
-                token_endpoint_env: "",
+                token_capability: TokenCapability::IntrospectOnly,
             },
             ProviderKind::Ansattporten => ProviderEnv {
                 provider_name: "ansattporten",
                 well_known_env: "ANSATTPORTEN_WELL_KNOWN_URL",
                 issuer_env: "ANSATTPORTEN_ISSUER",
                 jwks_uri_env: "ANSATTPORTEN_JWKS_URI",
-                token_endpoint_env: "",
+                token_capability: TokenCapability::IntrospectOnly,
             },
             ProviderKind::Maskinporten => ProviderEnv {
                 provider_name: "maskinporten",
                 well_known_env: "MASKINPORTEN_WELL_KNOWN_URL",
                 issuer_env: "MASKINPORTEN_ISSUER",
                 jwks_uri_env: "MASKINPORTEN_JWKS_URI",
-                token_endpoint_env: "MASKINPORTEN_TOKEN_ENDPOINT",
+                token_capability: TokenCapability::Exchange("MASKINPORTEN_TOKEN_ENDPOINT"),
             },
             ProviderKind::TokenX => ProviderEnv {
                 provider_name: "tokenx",
                 well_known_env: "TOKEN_X_WELL_KNOWN_URL",
                 issuer_env: "TOKEN_X_ISSUER",
                 jwks_uri_env: "TOKEN_X_JWKS_URI",
-                token_endpoint_env: "TOKEN_X_TOKEN_ENDPOINT",
+                token_capability: TokenCapability::Exchange("TOKEN_X_TOKEN_ENDPOINT"),
             },
         }
     }
@@ -252,7 +257,7 @@ impl RawProvider {
         let should_fetch_metadata = self.well_known_url.is_some()
             && (self.issuer.is_none()
                 || self.jwks_uri.is_none()
-                || (kind != ProviderKind::IDPorten && kind != ProviderKind::Ansattporten && self.token_endpoint.is_none()));
+                || (matches!(env.token_capability, TokenCapability::Exchange(_)) && self.token_endpoint.is_none()));
 
         let metadata = if should_fetch_metadata {
             let url = self.well_known_url.as_deref().unwrap_or_default();
@@ -275,12 +280,14 @@ impl RawProvider {
             })?;
         let token_endpoint = self.token_endpoint.or(metadata.token_endpoint);
 
-        if kind != ProviderKind::IDPorten && kind != ProviderKind::Ansattporten && token_endpoint.is_none() {
-            return Err(Error::MissingProviderConfigField {
-                provider: env.provider_name,
-                field_env: env.token_endpoint_env,
-                well_known_env: env.well_known_env,
-            });
+        if let TokenCapability::Exchange(field_env) = env.token_capability {
+            if token_endpoint.is_none() {
+                return Err(Error::MissingProviderConfigField {
+                    provider: env.provider_name,
+                    field_env,
+                    well_known_env: env.well_known_env,
+                });
+            }
         }
 
         Ok(Provider {

--- a/src/handler/state.rs
+++ b/src/handler/state.rs
@@ -101,6 +101,20 @@ impl State {
             providers.push(provider);
         }
 
+        if let Some(provider_cfg) = &cfg.ansattporten {
+            debug!(
+                "Fetch JWKS for Ansattporten from '{}'...",
+                provider_cfg.jwks_uri
+            );
+            let provider = new::<(), ()>(
+                IdentityProvider::Ansattporten,
+                provider_cfg,
+                Some(provider_cfg.client_id.clone()),
+            )
+            .await?;
+            providers.push(provider);
+        }
+
         Ok(Self {
             cfg,
             providers,

--- a/src/oauth/identity_provider.rs
+++ b/src/oauth/identity_provider.rs
@@ -51,6 +51,9 @@ pub enum TokenType {
 /// - [ID-porten](https://doc.nais.io/auth/idporten/reference/#claims)
 /// - [Maskinporten](https://doc.nais.io/auth/maskinporten/reference/#claims)
 /// - [TokenX](https://doc.nais.io/auth/tokenx/reference/#claims)
+///
+/// For Ansattporten specifically, please refer to the Digdir documentation for details:
+/// - [Ansattporten](https://docs.digdir.no/docs/ansattporten/ansattporten_om.html)
 #[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Clone)]
 pub struct IntrospectResponse {
     /// Indicates whether the token is valid. If this field is _false_,
@@ -206,6 +209,8 @@ pub enum IdentityProvider {
     Maskinporten,
     #[serde(rename = "idporten")]
     IDPorten,
+    #[serde(rename = "ansattporten")]
+    Ansattporten,
 }
 
 impl Display for IdentityProvider {
@@ -654,6 +659,7 @@ mod tests {
     #[case("tokenx", IdentityProvider::TokenX)]
     #[case("maskinporten", IdentityProvider::Maskinporten)]
     #[case("idporten", IdentityProvider::IDPorten)]
+    #[case("ansattporten", IdentityProvider::Ansattporten)]
     fn valid_identity_provider_should_deserialize(
         #[case] input: String,
         #[case] expected: IdentityProvider,

--- a/tests/integration/helpers/config.rs
+++ b/tests/integration/helpers/config.rs
@@ -33,6 +33,13 @@ pub fn mock(host: String, port: u16) -> Config {
             issuer: format!("{url_base}/idporten"),
             token_endpoint: None,
         }),
+        ansattporten: Some(Provider {
+            client_id: "default".to_string(), // expected audience for tokens returned by mock-oauth2-server
+            client_jwk: None,
+            jwks_uri: format!("{url_base}/ansattporten/jwks"),
+            issuer: format!("{url_base}/ansattporten"),
+            token_endpoint: None,
+        }),
     }
 }
 
@@ -44,5 +51,6 @@ pub fn mock_no_providers() -> Config {
         entra_id: None,
         token_x: None,
         idporten: None,
+        ansattporten: None,
     }
 }

--- a/tests/integration/helpers/docker.rs
+++ b/tests/integration/helpers/docker.rs
@@ -29,6 +29,7 @@ impl RuntimeParams {
             .with_exposed_port(8080.tcp())
             .with_wait_for(wait_for_provider("entra_id"))
             .with_wait_for(wait_for_provider("idporten"))
+            .with_wait_for(wait_for_provider("ansattporten"))
             .with_wait_for(wait_for_provider("maskinporten"))
             .with_wait_for(wait_for_provider("tokenx"))
             .with_env_var("JSON_CONFIG", MockOAuthServerConfig::new().to_json())

--- a/tests/integration/helpers/server.rs
+++ b/tests/integration/helpers/server.rs
@@ -74,6 +74,10 @@ impl TestServer {
         self.cfg.idporten.clone().unwrap().issuer
     }
 
+    pub fn ansattporten_issuer(&self) -> String {
+        self.cfg.ansattporten.clone().unwrap().issuer
+    }
+
     pub fn maskinporten_issuer(&self) -> String {
         self.cfg.maskinporten.clone().unwrap().issuer
     }

--- a/tests/integration/providers_not_enabled.rs
+++ b/tests/integration/providers_not_enabled.rs
@@ -21,6 +21,7 @@ async fn all_providers() {
     let providers = [
         IdentityProvider::EntraID,
         IdentityProvider::IDPorten,
+        IdentityProvider::Ansattporten,
         IdentityProvider::Maskinporten,
         IdentityProvider::TokenX,
     ];

--- a/tests/integration/token.rs
+++ b/tests/integration/token.rs
@@ -210,7 +210,7 @@ async fn test_token_invalid_identity_provider(address: &str) {
     assert_eq!(error_response.error, OAuthErrorCode::InvalidRequest);
     assert_eq!(
         error_response.description,
-        "Failed to deserialize the JSON body into the target type: identity_provider: unknown variant `invalid`, expected one of `azuread`, `entra_id`, `tokenx`, `maskinporten`, `idporten` at line 1 column 30"
+        "Failed to deserialize the JSON body into the target type: identity_provider: unknown variant `invalid`, expected one of `azuread`, `entra_id`, `tokenx`, `maskinporten`, `idporten`, `ansattporten` at line 1 column 30"
     );
 
     let http_response = post_request(
@@ -225,7 +225,7 @@ async fn test_token_invalid_identity_provider(address: &str) {
     assert_eq!(error_response.error, OAuthErrorCode::InvalidRequest);
     assert_eq!(
         error_response.description,
-        "Failed to deserialize form body: identity_provider: unknown variant `invalid`, expected one of `azuread`, `entra_id`, `tokenx`, `maskinporten`, `idporten`"
+        "Failed to deserialize form body: identity_provider: unknown variant `invalid`, expected one of `azuread`, `entra_id`, `tokenx`, `maskinporten`, `idporten`, `ansattporten`"
     );
 }
 

--- a/tests/integration/token_introspect.rs
+++ b/tests/integration/token_introspect.rs
@@ -23,6 +23,7 @@ async fn all_providers() {
     let identity_provider_address = server.identity_provider_address();
     let azure_issuer = server.azure_issuer();
     let idporten_issuer = server.idporten_issuer();
+    let ansattporten_issuer = server.ansattporten_issuer();
     let maskinporten_issuer = server.maskinporten_issuer();
     let token_x_issuer = server.token_x_issuer();
 
@@ -46,6 +47,15 @@ async fn all_providers() {
             &address,
             &identity_provider_address,
             IdentityProvider::IDPorten,
+            format.clone(),
+        )
+        .await;
+
+        introspect_token(
+            &ansattporten_issuer,
+            &address,
+            &identity_provider_address,
+            IdentityProvider::Ansattporten,
             format.clone(),
         )
         .await;


### PR DESCRIPTION
Similar to what was done for ID-Porten in
f1e7129edc598f78c5915978d2dcc0c998e77e40.

This solves issue https://github.com/nais/texas/issues/111

Question: in `identity_provider.rs` (and the corresponding generated docs), there are links to https://doc.nais.io/auth/, for instance https://doc.nais.io/auth/maskinporten/reference/#claims, which describes claims for each provider. There is no such page for Ansattporten. Would you prefer to add similar documentation for Ansattporten in the Nais docs, and link to that instead of the Digdir page I'm currently linking to?

Context: At Kartverket, we want teams to be able to validate and exchange tokens for all relevant providers. This includes Ansattporten. Exchanging Ansattporten-tokens is (as far as I understand) already supported, however validating is not.